### PR TITLE
feat(metrics): tenant-scoped business metrics for the notification lifecycle

### DIFF
--- a/apps/default/service/events/metrics.go
+++ b/apps/default/service/events/metrics.go
@@ -1,0 +1,95 @@
+package events
+
+import (
+	"context"
+	"time"
+
+	commonv1 "buf.build/gen/go/antinvestor/common/protocolbuffers/go/common/v1"
+	"github.com/antinvestor/service-notification/apps/default/service/models"
+	"github.com/pitabwire/frame/telemetry"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// Business metric instruments for the notification lifecycle.
+//
+// Every instrument is tenant-scoped transparently: frame's
+// telemetry.BusinessMetrics attaches tenant_id and partition_id from the
+// context's security claims on every measurement, and frame's queue layer
+// propagates those claims from the originating request into event handlers.
+var (
+	businessMetrics = telemetry.NewBusinessMetrics("service-notification")
+
+	notificationsQueuedTotal = businessMetrics.Counter(
+		"notifications_queued_total",
+		"Notifications accepted and queued for processing",
+	)
+	notificationsSentTotal = businessMetrics.Counter(
+		"notifications_sent_total",
+		"Outbound notifications dispatched to a delivery route",
+	)
+	notificationsDeliveredTotal = businessMetrics.Counter(
+		"notifications_delivered_total",
+		"Outbound notifications confirmed delivered by their route",
+	)
+	notificationsFailedTotal = businessMetrics.Counter(
+		"notifications_failed_total",
+		"Notifications that failed processing or delivery",
+	)
+	notificationsSendDuration = businessMetrics.Histogram(
+		"notifications_send_duration_ms",
+		"Time from notification creation to dispatch on a delivery route",
+	)
+)
+
+const unknownAttrValue = "unknown"
+
+func notificationChannel(n *models.Notification) string {
+	if n == nil || n.NotificationType == "" {
+		return unknownAttrValue
+	}
+	return n.NotificationType
+}
+
+func failureReason(nStatus *models.NotificationStatus) string {
+	if reason := nStatus.Extra.GetString("step"); reason != "" {
+		return reason
+	}
+	return unknownAttrValue
+}
+
+// recordStatusMetrics translates a persisted notification status transition
+// into business metrics. NotificationStatusSave is the single sink through
+// which every lifecycle transition flows, so recording here covers queueing,
+// dispatch, delivery confirmations and failures from all paths.
+func recordStatusMetrics(ctx context.Context, n *models.Notification, nStatus *models.NotificationStatus) {
+	channelAttr := attribute.String("channel", notificationChannel(n))
+
+	switch commonv1.STATUS(nStatus.Status) {
+	case commonv1.STATUS_QUEUED:
+		// Re-queue transitions (routing, release) carry STATE_ACTIVE; only
+		// count first acceptance so each notification is queued once.
+		if commonv1.STATE(nStatus.State) != commonv1.STATE_CREATED {
+			return
+		}
+		notificationsQueuedTotal.Add(ctx, 1, channelAttr)
+	case commonv1.STATUS_IN_PROCESS:
+		if !n.OutBound {
+			return
+		}
+		attrs := []attribute.KeyValue{channelAttr}
+		if n.TemplateID != "" {
+			attrs = append(attrs, attribute.String("template", n.TemplateID))
+		}
+		notificationsSentTotal.Add(ctx, 1, attrs...)
+		notificationsSendDuration.Record(ctx, float64(time.Since(n.CreatedAt).Milliseconds()), channelAttr)
+	case commonv1.STATUS_SUCCESSFUL:
+		if !n.OutBound {
+			return
+		}
+		notificationsDeliveredTotal.Add(ctx, 1, channelAttr)
+	case commonv1.STATUS_FAILED:
+		notificationsFailedTotal.Add(ctx, 1, channelAttr, attribute.String("reason", failureReason(nStatus)))
+	default:
+		// Other statuses are not lifecycle transitions we report on.
+	}
+}

--- a/apps/default/service/events/metrics_test.go
+++ b/apps/default/service/events/metrics_test.go
@@ -1,0 +1,111 @@
+package events
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	commonv1 "buf.build/gen/go/antinvestor/common/protocolbuffers/go/common/v1"
+	"github.com/antinvestor/service-notification/apps/default/service/models"
+	"github.com/pitabwire/frame/data"
+	"github.com/pitabwire/frame/security"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func metricAttrSets(rm metricdata.ResourceMetrics, name string) []attribute.Set {
+	var out []attribute.Set
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			switch d := m.Data.(type) {
+			case metricdata.Sum[int64]:
+				for _, dp := range d.DataPoints {
+					out = append(out, dp.Attributes)
+				}
+			case metricdata.Histogram[float64]:
+				for _, dp := range d.DataPoints {
+					out = append(out, dp.Attributes)
+				}
+			}
+		}
+	}
+	return out
+}
+
+func requireAttr(t *testing.T, set attribute.Set, key, want string) {
+	t.Helper()
+	v, ok := set.Value(attribute.Key(key))
+	require.True(t, ok, "attribute %q must be present", key)
+	require.Equal(t, want, v.AsString(), "attribute %q", key)
+}
+
+// Notification lifecycle counters must transparently carry tenant_id and
+// partition_id from the request context claims alongside their business
+// attributes.
+func TestRecordStatusMetricsTenantScoped(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(provider)
+	t.Cleanup(func() { otel.SetMeterProvider(prev) })
+
+	claims := &security.AuthenticationClaims{TenantID: "tenant-x", PartitionID: "part-y"}
+	claims.Subject = "user-tenant-x"
+	ctx := claims.ClaimsToContext(context.Background())
+
+	n := &models.Notification{
+		NotificationType: "sms",
+		OutBound:         true,
+		TemplateID:       "tmpl-1",
+	}
+	n.CreatedAt = time.Now().Add(-250 * time.Millisecond)
+
+	recordStatusMetrics(ctx, n, &models.NotificationStatus{
+		State:  int32(commonv1.STATE_CREATED.Number()),
+		Status: int32(commonv1.STATUS_QUEUED.Number()),
+	})
+	// Re-queue after routing must not double count acceptance.
+	recordStatusMetrics(ctx, n, &models.NotificationStatus{
+		State:  int32(commonv1.STATE_ACTIVE.Number()),
+		Status: int32(commonv1.STATUS_QUEUED.Number()),
+	})
+	recordStatusMetrics(ctx, n, &models.NotificationStatus{
+		Status: int32(commonv1.STATUS_IN_PROCESS.Number()),
+	})
+	recordStatusMetrics(ctx, n, &models.NotificationStatus{
+		Status: int32(commonv1.STATUS_SUCCESSFUL.Number()),
+	})
+	recordStatusMetrics(ctx, n, &models.NotificationStatus{
+		Status: int32(commonv1.STATUS_FAILED.Number()),
+		Extra:  data.JSONMap{"step": "publish_to_queue"},
+	})
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	for _, name := range []string{
+		"notifications_queued_total",
+		"notifications_sent_total",
+		"notifications_delivered_total",
+		"notifications_failed_total",
+		"notifications_send_duration_ms",
+	} {
+		sets := metricAttrSets(rm, name)
+		require.Len(t, sets, 1, "%s must have exactly one datapoint", name)
+		requireAttr(t, sets[0], "tenant_id", "tenant-x")
+		requireAttr(t, sets[0], "partition_id", "part-y")
+		requireAttr(t, sets[0], "channel", "sms")
+	}
+
+	sentSets := metricAttrSets(rm, "notifications_sent_total")
+	requireAttr(t, sentSets[0], "template", "tmpl-1")
+
+	failedSets := metricAttrSets(rm, "notifications_failed_total")
+	requireAttr(t, failedSets[0], "reason", "publish_to_queue")
+}

--- a/apps/default/service/events/notification_status_save.go
+++ b/apps/default/service/events/notification_status_save.go
@@ -55,9 +55,11 @@ func (e *NotificationStatusSave) Execute(ctx context.Context, payload any) error
 	defer logger.Release()
 	logger.Debug("event handler started")
 
+	isDuplicate := false
 	err := e.notificationStatusRepo.Create(ctx, nStatus)
 	if err != nil {
 		if data.ErrorIsDuplicateKey(err) {
+			isDuplicate = true
 			logger.Debug("notification status already exists, skipping duplicate")
 		} else {
 			logger.WithError(err).Error("could not save notification status to db")
@@ -81,6 +83,10 @@ func (e *NotificationStatusSave) Execute(ctx context.Context, payload any) error
 	if err != nil {
 		logger.WithError(err).Error("could not save notification update to db")
 		return err
+	}
+
+	if !isDuplicate {
+		recordStatusMetrics(ctx, n, nStatus)
 	}
 
 	logger.Debug("event handler completed successfully")

--- a/go.mod
+++ b/go.mod
@@ -18,11 +18,13 @@ require (
 	github.com/antinvestor/common v1.5.0
 	github.com/gorilla/mux v1.8.1
 	github.com/linxGnu/gosmpp v0.3.1
-	github.com/pitabwire/frame v1.98.0
-	github.com/pitabwire/util v0.9.0
+	github.com/pitabwire/frame v1.98.4
+	github.com/pitabwire/util v0.9.1
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/wneessen/go-mail v0.7.3
+	go.opentelemetry.io/otel v1.44.0
+	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11
 	gorm.io/gorm v1.31.1
@@ -121,7 +123,6 @@ require (
 	go.opentelemetry.io/contrib/propagators/b3 v1.44.0 // indirect
 	go.opentelemetry.io/contrib/propagators/jaeger v1.44.0 // indirect
 	go.opentelemetry.io/contrib/propagators/ot v1.44.0 // indirect
-	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.20.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.20.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0 // indirect
@@ -137,7 +138,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.44.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.20.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -204,12 +204,12 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.1 h1:BWvU2wHpyXWxhhNXsGB6JXLCNbshyLd1QxvoAmZnu10=
 github.com/panjf2000/ants/v2 v2.12.1/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame v1.98.0 h1:c/kbZxvM7IUekl/nzFe9F1jrEzSGp/Y9N3qEInpKv+4=
-github.com/pitabwire/frame v1.98.0/go.mod h1:SFbceOJiJdvM9iTwf1CkCWlUQylvp7fPpB1GDP4Pz20=
+github.com/pitabwire/frame v1.98.4 h1:yGrVLMlc+2rqHMoXL124VZ7RJW/zHyqkaZ4R7TP7HiQ=
+github.com/pitabwire/frame v1.98.4/go.mod h1:k6TV0rPXAgR8hG5CH3vjqepmitIiw5EvHVM7dfR1xV8=
 github.com/pitabwire/natspubsub v0.8.4 h1:iXncMM/Fuvmyu3+VFDazOxKf5M3AWNQZdvLpM+NtKZ0=
 github.com/pitabwire/natspubsub v0.8.4/go.mod h1:h2S81+ro+eB1NeWWDbhK4EkEN/A72o7hnrDXTUq67Js=
-github.com/pitabwire/util v0.9.0 h1:fnlTAuWKqAjc6GalO+a7hMeo6g3fAv5yjmaP237ChP4=
-github.com/pitabwire/util v0.9.0/go.mod h1:JrLiS3K4VXsLZE38LLvq1N0X2j0fs33QLz/zMXf3zc4=
+github.com/pitabwire/util v0.9.1 h1:V8Ag8TNGXoLztuTCbItj67MmQSS+ObEPzQipUCo2NKY=
+github.com/pitabwire/util v0.9.1/go.mod h1:JrLiS3K4VXsLZE38LLvq1N0X2j0fs33QLz/zMXf3zc4=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -225,8 +225,8 @@ github.com/prometheus/otlptranslator v1.0.0 h1:s0LJW/iN9dkIH+EnhiD3BlkkP5QVIUVEo
 github.com/prometheus/otlptranslator v1.0.0/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
 github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
-github.com/redis/go-redis/v9 v9.19.0 h1:XPVaaPSnG6RhYf7p+rmSa9zZfeVAnWsH5h3lxthOm/k=
-github.com/redis/go-redis/v9 v9.19.0/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3baQf57KlIkA=
+github.com/redis/go-redis/v9 v9.20.0 h1:WnQYxLkgO2xiXTCJY0ldIiI8dNqCDlQAG+AtaH7a2a0=
+github.com/redis/go-redis/v9 v9.20.0/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3baQf57KlIkA=
 github.com/rodaine/protogofakeit v0.1.1 h1:ZKouljuRM3A+TArppfBqnH8tGZHOwM/pjvtXe9DaXH8=
 github.com/rodaine/protogofakeit v0.1.1/go.mod h1:pXn/AstBYMaSfc1/RqH3N82pBuxtWgejz1AlYpY1mI0=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=


### PR DESCRIPTION
## Summary

Adds first-class business instrumentation for the notification lifecycle so the analytics pages have real data. Instruments are created via frame's `telemetry.NewBusinessMetrics`, so every datapoint transparently carries `tenant_id` / `partition_id` from the request context claims (frame's queue layer propagates claims into event handlers).

### Metrics (contract for analytics)

| Metric | Type | Attributes | Recorded at |
|---|---|---|---|
| `notifications_queued_total` | counter | `channel` | status sink, on `STATUS_QUEUED` |
| `notifications_sent_total` | counter | `channel`, `template` (when set) | status sink, on `STATUS_IN_PROCESS` for outbound (dispatched to delivery route) |
| `notifications_delivered_total` | counter | `channel` | status sink, on `STATUS_SUCCESSFUL` for outbound |
| `notifications_failed_total` | counter | `channel`, `reason` | status sink, on `STATUS_FAILED` (reason = bounded `step` from status extras) |
| `notifications_send_duration_ms` | histogram | `channel` | creation -> dispatch latency, recorded with `notifications_sent_total` |

### Design

- All lifecycle transitions funnel through the `NotificationStatusSave` event handler (`apps/default/service/events/notification_status_save.go`) — recording there covers QueueOut/QueueIn/Release/StatusUpdate and every internal failure path with one hook.
- Duplicate status redeliveries (duplicate-key on insert) are not recorded, avoiding at-least-once double counting.
- `channel` comes from the notification type (`sms` / `email`), `reason` from the bounded `step` written by failure paths.

### Testing

- `TestRecordStatusMetricsTenantScoped` (ManualReader) proves each instrument records exactly one datapoint carrying `tenant_id`/`partition_id` from claims ctx plus business attributes.
- `go build ./...` clean, `golangci-lint` 0 issues on changed packages, events suite green with `-count=1`.
