### PR TITLE
feat(ui): source notification dashboard analytics from the thesa metrics gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ coverage.html
 .tmp/
 WORK_STATE.md
 .claude/
+
+# Local-only pub dependency overrides (path overrides for unpublished packages)
+pubspec_overrides.yaml

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.3.0
+
+- `NotificationDashboardScreen` now sources KPIs (sent, delivered, failed,
+  queued, avg send time), the sent trend, and the channel mix from the thesa
+  analytics gate via `antinvestor_ui_core`'s `analyticsDataSourceProvider`,
+  using the `notifications_*` business metrics. The top failing templates
+  panel stays derived from the notification search snapshot.
+- Added `notificationAnalyticsSpec` (a `ServiceAnalyticsSpec`) for host apps
+  to register on their `ThesaAnalyticsDataSource`, plus
+  `analyticsGateMessage` for friendly gate error states (400 allowlist,
+  403 unscoped, 5xx backend down).
+- Requires `antinvestor_ui_core` >= 0.5.0 (unpublished; use a local path
+  override during development).
+
 ## 0.2.0
 
 - Added `NotificationDashboardScreen` (KPIs, channel mix, top failing

--- a/ui/lib/antinvestor_ui_notification.dart
+++ b/ui/lib/antinvestor_ui_notification.dart
@@ -4,6 +4,9 @@
 /// receiving, searching notifications, and managing templates.
 library;
 
+// Analytics
+export 'src/analytics/notification_analytics.dart';
+
 // Providers
 export 'src/providers/notification_transport_provider.dart';
 export 'src/providers/tenancy_aware_providers.dart';

--- a/ui/lib/src/analytics/notification_analytics.dart
+++ b/ui/lib/src/analytics/notification_analytics.dart
@@ -1,0 +1,97 @@
+import 'package:antinvestor_ui_core/antinvestor_ui_core.dart';
+import 'package:flutter/material.dart';
+
+/// Metric names emitted by service-notification's business instrumentation
+/// (`notifications_*` counters in apps/default/service/events/metrics.go).
+const String notificationsSentMetric = 'notifications_sent_total';
+const String notificationsDeliveredMetric = 'notifications_delivered_total';
+const String notificationsFailedMetric = 'notifications_failed_total';
+const String notificationsQueuedMetric = 'notifications_queued_total';
+const String notificationsSendDurationMetric = 'notifications_send_duration_ms';
+
+/// Analytics catalog for the notification service, consumed by the
+/// thesa-gated metrics pipeline.
+///
+/// Host apps register this spec on their [ThesaAnalyticsDataSource]:
+///
+/// ```dart
+/// analyticsDataSourceProvider.overrideWith(
+///   (ref) => ThesaAnalyticsDataSource(
+///     transport,
+///     specs: [notificationAnalyticsSpec],
+///   ),
+/// );
+/// ```
+///
+/// Tenant scoping is injected server-side from the caller's JWT; no
+/// tenant/partition filters are declared (or ever sent) here.
+const ServiceAnalyticsSpec notificationAnalyticsSpec = ServiceAnalyticsSpec(
+  service: 'notification',
+  kpis: [
+    KpiSpec(
+      'sent',
+      label: 'Sent',
+      metric: notificationsSentMetric,
+      unit: 'count',
+      icon: Icons.send_outlined,
+    ),
+    KpiSpec(
+      'delivered',
+      label: 'Delivered',
+      metric: notificationsDeliveredMetric,
+      unit: 'count',
+      icon: Icons.check_circle_outline,
+    ),
+    KpiSpec(
+      'failed',
+      label: 'Failed',
+      metric: notificationsFailedMetric,
+      unit: 'count',
+      icon: Icons.error_outline,
+    ),
+    KpiSpec(
+      'queued',
+      label: 'Queued',
+      metric: notificationsQueuedMetric,
+      unit: 'count',
+      icon: Icons.schedule_outlined,
+    ),
+    KpiSpec(
+      'avg_send_ms',
+      label: 'Avg send time (ms)',
+      metric: notificationsSendDurationMetric,
+      aggregation: AnalyticsAggregation.avg,
+      icon: Icons.speed_outlined,
+    ),
+  ],
+  charts: [
+    ChartConfig.timeSeries(
+      notificationsSentMetric,
+      label: 'Notifications sent',
+    ),
+    ChartConfig.distribution(
+      notificationsSentMetric,
+      groupBy: 'channel',
+      label: 'Channel mix',
+    ),
+  ],
+);
+
+/// Maps analytics gate failures to short, user-facing messages.
+///
+/// The gate's error contract: 400 -> metric rejected by the server-side
+/// allowlist, 403 -> caller's JWT carries no tenant scope, 5xx -> metrics
+/// backend unreachable.
+String analyticsGateMessage(Object error) {
+  if (error is AnalyticsQueryException) {
+    return switch (error.statusCode) {
+      400 => 'This metric is not available from the analytics gate.',
+      403 => 'Analytics are not available for your current sign-in scope.',
+      >= 500 =>
+        'The analytics backend is temporarily unavailable. '
+            'Please try again shortly.',
+      _ => 'Could not load analytics (HTTP ${error.statusCode}).',
+    };
+  }
+  return 'Could not load analytics.';
+}

--- a/ui/lib/src/screens/notification_dashboard_screen.dart
+++ b/ui/lib/src/screens/notification_dashboard_screen.dart
@@ -2,133 +2,325 @@ import 'package:antinvestor_ui_core/antinvestor_ui_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../analytics/notification_analytics.dart';
 import '../providers/notification_providers.dart';
 import '../providers/stats_providers.dart';
 
 /// Top-level dashboard for the partition's notification activity.
 ///
-/// Composes `ServiceAnalyticsPage` from ui_core. Data comes from
-/// `notificationStatsProvider` (derived from the current search snapshot).
-class NotificationDashboardScreen extends ConsumerWidget {
+/// KPIs, the sent trend, and the channel mix come from the thesa analytics
+/// gate ([analyticsDataSourceProvider]) using the notification service's
+/// business metrics. The "Top failing templates" panel stays entity-derived
+/// from the current search snapshot. Tenant scoping is injected server-side;
+/// this screen never sends tenant or partition filters.
+class NotificationDashboardScreen extends ConsumerStatefulWidget {
   const NotificationDashboardScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    // Trigger the underlying search so stats has data.
+  ConsumerState<NotificationDashboardScreen> createState() =>
+      _NotificationDashboardScreenState();
+}
+
+class _NotificationDashboardScreenState
+    extends ConsumerState<NotificationDashboardScreen> {
+  AnalyticsTimeRange _timeRange = AnalyticsTimeRange.last30Days();
+
+  static const String _service = 'notification';
+
+  ServiceMetricsParams get _metricsParams =>
+      ServiceMetricsParams(_service, timeRange: _timeRange);
+
+  ServiceTimeSeriesParams get _trendParams => ServiceTimeSeriesParams(
+    _service,
+    notificationsSentMetric,
+    timeRange: _timeRange,
+  );
+
+  ServiceDistributionParams get _channelMixParams => ServiceDistributionParams(
+    _service,
+    notificationsSentMetric,
+    'channel',
+    timeRange: _timeRange,
+  );
+
+  void _refresh() {
+    ref
+      ..invalidate(serviceMetricsProvider(_metricsParams))
+      ..invalidate(serviceTimeSeriesProvider(_trendParams))
+      ..invalidate(serviceDistributionProvider(_channelMixParams));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Trigger the underlying search so the entity-derived panel has data.
     ref.watch(notificationSearchProvider(const NotificationSearchParams()));
     final stats = ref.watch(notificationStatsProvider);
     final tenancy = ref.watch(tenancyContextProvider);
 
+    final metricsAsync = ref.watch(serviceMetricsProvider(_metricsParams));
+    final trendAsync = ref.watch(serviceTimeSeriesProvider(_trendParams));
+    final mixAsync = ref.watch(serviceDistributionProvider(_channelMixParams));
+
     final crumbs = <String>['Home', ...tenancy.breadcrumbs, 'Notifications'];
+    final isDesktop = AppBreakpoints.isDesktop(
+      MediaQuery.sizeOf(context).width,
+    );
 
-    final kpis = <ServiceKpi>[
-      ServiceKpi(
-        label: 'Sent',
-        value: '${stats.sent}',
-        icon: Icons.send_outlined,
+    final trendCard = _ChartCard(
+      title: 'Notifications sent',
+      subtitle: 'Dispatch volume over time',
+      child: trendAsync.when(
+        data: (series) => TimeSeriesChart(
+          series: series,
+          granularity: _timeRange.granularity,
+        ),
+        loading: () => const _ChartLoading(),
+        error: (e, _) => AnalyticsGateErrorCard(
+          message: analyticsGateMessage(e),
+          onRetry: _refresh,
+        ),
       ),
-      ServiceKpi(
-        label: 'Delivered',
-        value: '${stats.delivered}',
-        icon: Icons.check_circle_outline,
-        changePositive: true,
-      ),
-      ServiceKpi(
-        label: 'Failed',
-        value: '${stats.failed}',
-        icon: Icons.error_outline,
-        changePositive: false,
-      ),
-      ServiceKpi(
-        label: 'Queued',
-        value: '${stats.queued}',
-        icon: Icons.schedule_outlined,
-      ),
-    ];
+    );
 
-    final events = stats.topFailing
-        .map((e) => ServiceEvent(
-              title: '${e.template} — ${e.failures} failure(s)',
-              timeAgo: '',
-              severity: EventSeverity.error,
-              icon: Icons.error_outline,
-            ))
-        .toList();
+    final mixCard = _ChartCard(
+      title: 'Channel mix',
+      subtitle: 'Notifications sent by channel',
+      child: mixAsync.when(
+        data: (segments) => DistributionChart(segments: segments),
+        loading: () => const _ChartLoading(),
+        error: (e, _) => AnalyticsGateErrorCard(
+          message: analyticsGateMessage(e),
+          onRetry: _refresh,
+        ),
+      ),
+    );
 
-    return ServiceAnalyticsPage(
-      title: 'Notifications',
-      breadcrumbs: crumbs,
-      kpis: kpis,
-      chartTitle: 'Channel mix',
-      chartSubtitle: 'Distribution of recent notifications by channel',
-      chartWidget: _ChannelMixBars(channelMix: stats.channelMix),
-      events: events,
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          PageHeader(
+            title: 'Notifications',
+            breadcrumbs: crumbs,
+            actions: [
+              IconButton(
+                icon: const Icon(Icons.refresh),
+                tooltip: 'Refresh',
+                onPressed: _refresh,
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: TimeRangeSelector(
+              value: _timeRange,
+              onChanged: (range) => setState(() => _timeRange = range),
+            ),
+          ),
+          const SizedBox(height: 20),
+          metricsAsync.when(
+            data: (metrics) => metrics.isEmpty
+                ? const AnalyticsGateErrorCard(
+                    message:
+                        'Analytics are not configured for the '
+                        'notification service in this app.',
+                  )
+                : MetricsRow(metrics: metrics),
+            loading: () => MetricsRow(
+              metrics: const [],
+              isLoading: true,
+              skeletonCount: notificationAnalyticsSpec.kpis.length,
+            ),
+            error: (e, _) => AnalyticsGateErrorCard(
+              message: analyticsGateMessage(e),
+              onRetry: _refresh,
+            ),
+          ),
+          const SizedBox(height: 20),
+          if (isDesktop)
+            IntrinsicHeight(
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Expanded(child: trendCard),
+                  const SizedBox(width: 16),
+                  Expanded(child: mixCard),
+                ],
+              ),
+            )
+          else ...[
+            trendCard,
+            const SizedBox(height: 16),
+            mixCard,
+          ],
+          const SizedBox(height: 20),
+          _TopFailingCard(topFailing: stats.topFailing),
+        ],
+      ),
     );
   }
 }
 
-/// Horizontal-bar visualization of channel mix. Avoids pulling in a
-/// chart dep; uses LinearProgressIndicator per channel.
-class _ChannelMixBars extends StatelessWidget {
-  const _ChannelMixBars({required this.channelMix});
-  final Map<String, int> channelMix;
+/// Friendly inline error/empty card for analytics gate failures.
+class AnalyticsGateErrorCard extends StatelessWidget {
+  const AnalyticsGateErrorCard({
+    super.key,
+    required this.message,
+    this.onRetry,
+  });
+
+  final String message;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: cs.errorContainer.withValues(alpha: 0.25),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.insights_outlined, color: cs.error, size: 20),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              message,
+              style: TextStyle(color: cs.error, fontSize: 13),
+            ),
+          ),
+          if (onRetry != null) ...[
+            const SizedBox(width: 8),
+            TextButton(onPressed: onRetry, child: const Text('Retry')),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _ChartCard extends StatelessWidget {
+  const _ChartCard({
+    required this.title,
+    required this.subtitle,
+    required this.child,
+  });
+
+  final String title;
+  final String subtitle;
+  final Widget child;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    if (channelMix.isEmpty) {
-      return SizedBox(
-        height: 200,
-        child: Center(
-          child: Text(
-            'No channel data',
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
+    final cs = theme.colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: cs.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: cs.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w600,
             ),
           ),
-        ),
-      );
-    }
-    final total = channelMix.values.fold<int>(0, (a, b) => a + b);
-    final entries = channelMix.entries.toList()
-      ..sort((a, b) => b.value.compareTo(a.value));
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        for (final e in entries)
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 4),
-            child: Row(
-              children: [
-                SizedBox(
-                  width: 80,
-                  child: Text(
-                    e.key,
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ),
-                Expanded(
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(4),
-                    child: LinearProgressIndicator(
-                      value: e.value / total,
-                      minHeight: 10,
-                      backgroundColor:
-                          theme.colorScheme.surfaceContainerHighest,
-                    ),
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Text(
-                  '${e.value}',
-                  style: theme.textTheme.bodyMedium,
-                ),
-              ],
+          const SizedBox(height: 4),
+          Text(
+            subtitle,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: cs.onSurfaceVariant,
             ),
           ),
-      ],
+          const SizedBox(height: 16),
+          child,
+        ],
+      ),
+    );
+  }
+}
+
+class _ChartLoading extends StatelessWidget {
+  const _ChartLoading();
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox(
+      height: 240,
+      child: Center(child: CircularProgressIndicator()),
+    );
+  }
+}
+
+/// Entity-derived panel: top failing templates from the search snapshot.
+class _TopFailingCard extends StatelessWidget {
+  const _TopFailingCard({required this.topFailing});
+
+  final List<({String template, int failures})> topFailing;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: cs.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: cs.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Top failing templates',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 12),
+          if (topFailing.isEmpty)
+            Text(
+              'No failures in the current snapshot',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: cs.onSurfaceVariant,
+              ),
+            )
+          else
+            for (final entry in topFailing)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: Row(
+                  children: [
+                    Icon(Icons.error_outline, size: 16, color: cs.error),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        entry.template,
+                        style: theme.textTheme.bodyMedium,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    Text(
+                      '${entry.failures} failure(s)',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: cs.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+        ],
+      ),
     );
   }
 }

--- a/ui/pubspec.yaml
+++ b/ui/pubspec.yaml
@@ -2,7 +2,7 @@ name: antinvestor_ui_notification
 description: >
   Notification management UI library for Antinvestor. Embeddable screens and widgets
   for sending, receiving, searching notifications, and managing templates.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/antinvestor/service-notification
 homepage: https://github.com/antinvestor/service-notification/tree/main/ui
 issue_tracker: https://github.com/antinvestor/service-notification/issues
@@ -19,7 +19,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  antinvestor_ui_core: ^0.1.0
+  # 0.5.0 ships the thesa-gated analytics pipeline (ServiceAnalyticsSpec,
+  # ThesaAnalyticsDataSource). Not on pub.dev yet -- develop against the
+  # local checkout via the gitignored pubspec_overrides.yaml.
+  antinvestor_ui_core: ^0.5.0
   antinvestor_api_notification: ^1.53.0
   antinvestor_api_common: ^1.52.0
   connectrpc: ^1.0.0
@@ -33,6 +36,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+  http: ^1.6.0
   build_runner: ^2.13.1
   riverpod_generator: ^4.0.3
   mocktail: ^1.0.4

--- a/ui/test/_helpers/fake_analytics_transport.dart
+++ b/ui/test/_helpers/fake_analytics_transport.dart
@@ -1,0 +1,32 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+/// Recording fake for the [AnalyticsTransport] used by
+/// `ThesaAnalyticsDataSource` in tests.
+///
+/// Captures every POSTed path + decoded JSON body and replies either via
+/// [handler] or with an empty success payload appropriate for the endpoint.
+class FakeAnalyticsTransport {
+  /// Every request made through this transport, in order.
+  final List<({String path, Map<String, dynamic> body})> calls = [];
+
+  /// Optional per-request response factory. When null, the transport
+  /// returns zero/empty payloads with HTTP 200.
+  http.Response Function(String path, Map<String, dynamic> body)? handler;
+
+  Future<http.Response> call(String path, {Object? body}) async {
+    final decoded = json.decode(body! as String) as Map<String, dynamic>;
+    calls.add((path: path, body: decoded));
+    final h = handler;
+    if (h != null) return h(path, decoded);
+    return http.Response(json.encode(_emptyPayloadFor(path)), 200);
+  }
+
+  static Map<String, dynamic> _emptyPayloadFor(String path) {
+    if (path.endsWith('/scalar')) return {'value': 0};
+    if (path.endsWith('/timeseries')) return {'points': <Object>[]};
+    if (path.endsWith('/grouped')) return {'segments': <Object>[]};
+    return {'items': <Object>[]};
+  }
+}

--- a/ui/test/_helpers/test_harness.dart
+++ b/ui/test/_helpers/test_harness.dart
@@ -8,16 +8,19 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'fake_notification_client.dart';
 
 /// Builds a [ProviderScope] wrapping [child] with an overridden
-/// [tenancyContextProvider] and, optionally, an overridden
-/// [notificationServiceClientProvider].
+/// [tenancyContextProvider] and, optionally, overridden
+/// [notificationServiceClientProvider] / [analyticsDataSourceProvider].
 ///
 /// Use [FakeNotificationClient] via the [client] parameter to inject canned
-/// responses in tests without network access.
+/// responses in tests without network access, and pass an
+/// [AnalyticsDataSource] (e.g. a `ThesaAnalyticsDataSource` over a
+/// `FakeAnalyticsTransport`) via [analytics] for gate-backed widgets.
 class TestHarness extends StatelessWidget {
   const TestHarness({
     super.key,
     required this.child,
     this.client,
+    this.analytics,
     this.partitionId = 'part-test',
     this.organizationId,
     this.branchId,
@@ -25,6 +28,7 @@ class TestHarness extends StatelessWidget {
 
   final Widget child;
   final FakeNotificationClient? client;
+  final AnalyticsDataSource? analytics;
   final String partitionId;
   final String? organizationId;
   final String? branchId;
@@ -47,6 +51,8 @@ class TestHarness extends StatelessWidget {
         tenancyContextProvider.overrideWithValue(tenancy),
         if (client != null)
           notificationServiceClientProvider.overrideWithValue(client!.client),
+        if (analytics != null)
+          analyticsDataSourceProvider.overrideWithValue(analytics!),
       ],
       child: MaterialApp(home: Scaffold(body: child)),
     );

--- a/ui/test/_helpers/test_harness.dart
+++ b/ui/test/_helpers/test_harness.dart
@@ -47,6 +47,9 @@ class TestHarness extends StatelessWidget {
       );
 
     return ProviderScope(
+      // Disable Riverpod's automatic retry so failed gate queries settle
+      // in their error state instead of flipping back to loading.
+      retry: (retryCount, error) => null,
       overrides: [
         tenancyContextProvider.overrideWithValue(tenancy),
         if (client != null)

--- a/ui/test/analytics/notification_analytics_contract_test.dart
+++ b/ui/test/analytics/notification_analytics_contract_test.dart
@@ -1,0 +1,176 @@
+import 'dart:convert';
+
+import 'package:antinvestor_ui_core/antinvestor_ui_core.dart';
+import 'package:antinvestor_ui_notification/antinvestor_ui_notification.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+import '../_helpers/fake_analytics_transport.dart';
+
+void main() {
+  final timeRange = AnalyticsTimeRange(
+    start: DateTime.utc(2026, 1, 1),
+    end: DateTime.utc(2026, 1, 31),
+    granularity: TimeGranularity.day,
+  );
+  const wireTimeRange = {
+    'start': '2026-01-01T00:00:00.000Z',
+    'end': '2026-01-31T00:00:00.000Z',
+  };
+
+  late FakeAnalyticsTransport transport;
+  late ThesaAnalyticsDataSource dataSource;
+
+  setUp(() {
+    transport = FakeAnalyticsTransport();
+    dataSource = ThesaAnalyticsDataSource(
+      transport.call,
+      specs: const [notificationAnalyticsSpec],
+    );
+  });
+
+  test('KPI fetch posts one exact scalar body per declared metric', () async {
+    await dataSource.getMetrics('notification', timeRange: timeRange);
+
+    expect(
+      transport.calls.map((c) => c.path),
+      everyElement('/api/analytics/query/scalar'),
+    );
+    expect(transport.calls.map((c) => c.body), [
+      {
+        'metric': 'notifications_sent_total',
+        'aggregation': 'sum',
+        'time_range': wireTimeRange,
+      },
+      {
+        'metric': 'notifications_delivered_total',
+        'aggregation': 'sum',
+        'time_range': wireTimeRange,
+      },
+      {
+        'metric': 'notifications_failed_total',
+        'aggregation': 'sum',
+        'time_range': wireTimeRange,
+      },
+      {
+        'metric': 'notifications_queued_total',
+        'aggregation': 'sum',
+        'time_range': wireTimeRange,
+      },
+      {
+        'metric': 'notifications_send_duration_ms',
+        'aggregation': 'avg',
+        'time_range': wireTimeRange,
+      },
+    ]);
+  });
+
+  test('sent trend posts an exact timeseries body with step', () async {
+    await dataSource.getTimeSeries(
+      'notification',
+      notificationsSentMetric,
+      timeRange: timeRange,
+    );
+
+    expect(transport.calls, hasLength(1));
+    expect(transport.calls.single.path, '/api/analytics/query/timeseries');
+    expect(transport.calls.single.body, {
+      'metric': 'notifications_sent_total',
+      'aggregation': 'sum',
+      'time_range': wireTimeRange,
+      'step': 'day',
+    });
+  });
+
+  test('channel mix posts an exact grouped body', () async {
+    await dataSource.getDistribution(
+      'notification',
+      notificationsSentMetric,
+      'channel',
+      timeRange: timeRange,
+    );
+
+    expect(transport.calls, hasLength(1));
+    expect(transport.calls.single.path, '/api/analytics/query/grouped');
+    expect(transport.calls.single.body, {
+      'metric': 'notifications_sent_total',
+      'aggregation': 'sum',
+      'group_by': 'channel',
+      'time_range': wireTimeRange,
+    });
+  });
+
+  test('no request ever carries tenant or partition filters', () async {
+    await dataSource.getMetrics('notification', timeRange: timeRange);
+    await dataSource.getTimeSeries(
+      'notification',
+      notificationsSentMetric,
+      timeRange: timeRange,
+    );
+    await dataSource.getDistribution(
+      'notification',
+      notificationsSentMetric,
+      'channel',
+      timeRange: timeRange,
+    );
+
+    for (final call in transport.calls) {
+      final filters =
+          (call.body['filters'] as Map<String, dynamic>?) ?? const {};
+      expect(filters.keys, isNot(contains('tenant_id')));
+      expect(filters.keys, isNot(contains('partition_id')));
+    }
+  });
+
+  test('gate errors surface status code and server message', () async {
+    transport.handler = (path, body) =>
+        http.Response(json.encode({'error': 'metric not allowed'}), 400);
+
+    await expectLater(
+      dataSource.getMetrics('notification', timeRange: timeRange),
+      throwsA(
+        isA<AnalyticsQueryException>()
+            .having((e) => e.statusCode, 'statusCode', 400)
+            .having((e) => e.message, 'message', 'metric not allowed'),
+      ),
+    );
+  });
+
+  test('analyticsGateMessage maps gate statuses to friendly text', () {
+    const path = '/api/analytics/query/scalar';
+    expect(
+      analyticsGateMessage(
+        const AnalyticsQueryException(
+          statusCode: 400,
+          message: 'metric not allowed',
+          path: path,
+        ),
+      ),
+      'This metric is not available from the analytics gate.',
+    );
+    expect(
+      analyticsGateMessage(
+        const AnalyticsQueryException(
+          statusCode: 403,
+          message: 'no tenant scope',
+          path: path,
+        ),
+      ),
+      'Analytics are not available for your current sign-in scope.',
+    );
+    expect(
+      analyticsGateMessage(
+        const AnalyticsQueryException(
+          statusCode: 503,
+          message: 'backend down',
+          path: path,
+        ),
+      ),
+      contains('temporarily unavailable'),
+    );
+    expect(
+      analyticsGateMessage(StateError('boom')),
+      'Could not load analytics.',
+    );
+  });
+}

--- a/ui/test/screens/notification_dashboard_screen_test.dart
+++ b/ui/test/screens/notification_dashboard_screen_test.dart
@@ -1,33 +1,147 @@
+import 'dart:convert';
+
 import 'package:antinvestor_api_notification/antinvestor_api_notification.dart'
     as notif;
+import 'package:antinvestor_ui_core/antinvestor_ui_core.dart';
 import 'package:antinvestor_ui_notification/antinvestor_ui_notification.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
 
+import '../_helpers/fake_analytics_transport.dart';
 import '../_helpers/fake_notification_client.dart';
 import '../_helpers/test_harness.dart';
 
 void main() {
-  testWidgets('renders KPI tiles from search snapshot', (tester) async {
-    final fake = FakeNotificationClient()
-      ..nextSearchResults = [
-        makeNotification(id: '1')
-          ..status = (notif.StatusResponse()..state = notif.STATE.ACTIVE),
-        makeNotification(id: '2')
-          ..status = (notif.StatusResponse()..state = notif.STATE.INACTIVE),
-        makeNotification(id: '3')
-          ..status = (notif.StatusResponse()..state = notif.STATE.CREATED),
-      ];
+  late FakeAnalyticsTransport transport;
+  late FakeNotificationClient client;
 
-    await tester.pumpWidget(TestHarness(
-      client: fake,
-      child: const NotificationDashboardScreen(),
-    ));
+  setUp(() {
+    transport = FakeAnalyticsTransport();
+    client = FakeNotificationClient();
+  });
+
+  Future<void> pumpDashboard(WidgetTester tester) async {
+    await tester.pumpWidget(
+      TestHarness(
+        client: client,
+        analytics: ThesaAnalyticsDataSource(
+          transport.call,
+          specs: const [notificationAnalyticsSpec],
+        ),
+        child: const NotificationDashboardScreen(),
+      ),
+    );
     await tester.pumpAndSettle();
+  }
+
+  testWidgets('renders gate-backed KPI cards from scalar queries', (
+    tester,
+  ) async {
+    transport.handler = (path, body) {
+      if (!path.endsWith('/scalar')) {
+        return http.Response(
+          json.encode({'points': <Object>[], 'segments': <Object>[]}),
+          200,
+        );
+      }
+      final value = switch (body['metric']) {
+        'notifications_sent_total' => 70,
+        'notifications_delivered_total' => 64,
+        'notifications_failed_total' => 6,
+        'notifications_queued_total' => 9,
+        'notifications_send_duration_ms' => 12.5,
+        _ => 0,
+      };
+      return http.Response(json.encode({'value': value}), 200);
+    };
+
+    await pumpDashboard(tester);
 
     expect(find.text('Sent'), findsOneWidget);
-    expect(find.text('3'), findsAtLeastNWidgets(1)); // sent (may also appear in channel mix)
+    expect(find.text('70'), findsOneWidget);
     expect(find.text('Delivered'), findsOneWidget);
+    expect(find.text('64'), findsOneWidget);
     expect(find.text('Failed'), findsOneWidget);
+    expect(find.text('6'), findsOneWidget);
     expect(find.text('Queued'), findsOneWidget);
+    expect(find.text('9'), findsOneWidget);
+    expect(find.text('Avg send time (ms)'), findsOneWidget);
+    expect(find.text('12.5'), findsOneWidget);
+  });
+
+  testWidgets('renders channel mix legend from the grouped query', (
+    tester,
+  ) async {
+    transport.handler = (path, body) {
+      if (path.endsWith('/grouped')) {
+        expect(body['metric'], 'notifications_sent_total');
+        expect(body['group_by'], 'channel');
+        return http.Response(
+          json.encode({
+            'segments': [
+              {'label': 'sms', 'value': 60},
+              {'label': 'email', 'value': 40},
+            ],
+          }),
+          200,
+        );
+      }
+      if (path.endsWith('/timeseries')) {
+        return http.Response(json.encode({'points': <Object>[]}), 200);
+      }
+      return http.Response(json.encode({'value': 0}), 200);
+    };
+
+    await pumpDashboard(tester);
+
+    expect(find.text('Channel mix'), findsOneWidget);
+    expect(find.text('sms'), findsOneWidget);
+    expect(find.text('email'), findsOneWidget);
+  });
+
+  testWidgets('shows empty chart states when the gate has no data', (
+    tester,
+  ) async {
+    await pumpDashboard(tester);
+
+    // Sent trend and channel mix both report no data.
+    expect(find.text('No data'), findsNWidgets(2));
+  });
+
+  for (final (status, fragment) in [
+    (400, 'not available from the analytics gate'),
+    (403, 'not available for your current sign-in scope'),
+    (503, 'temporarily unavailable'),
+  ]) {
+    testWidgets('renders friendly state for gate HTTP $status', (tester) async {
+      transport.handler = (path, body) =>
+          http.Response(json.encode({'error': 'gate says no'}), status);
+
+      await pumpDashboard(tester);
+
+      // KPI row plus both charts surface the same friendly message.
+      expect(find.textContaining(fragment), findsNWidgets(3));
+      expect(find.textContaining('gate says no'), findsNothing);
+      expect(find.text('Retry'), findsNWidgets(3));
+    });
+  }
+
+  testWidgets('keeps entity-derived top failing templates panel', (
+    tester,
+  ) async {
+    client.nextSearchResults = [
+      makeNotification(id: '1', template: 'welcome')
+        ..status = (notif.StatusResponse()..state = notif.STATE.INACTIVE),
+      makeNotification(id: '2', template: 'welcome')
+        ..status = (notif.StatusResponse()..state = notif.STATE.INACTIVE),
+      makeNotification(id: '3', template: 'otp')
+        ..status = (notif.StatusResponse()..state = notif.STATE.ACTIVE),
+    ];
+
+    await pumpDashboard(tester);
+
+    expect(find.text('Top failing templates'), findsOneWidget);
+    expect(find.text('welcome'), findsOneWidget);
+    expect(find.text('2 failure(s)'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
Converts `NotificationDashboardScreen` to the standardized thesa-gated metrics pipeline from `antinvestor_ui_core` 0.5.0.

- KPIs (Sent, Delivered, Failed, Queued, Avg send time) come from gate scalar queries over the new `notifications_*` business metrics
- Sent trend: timeseries query on `notifications_sent_total`
- Channel mix: grouped query on `notifications_sent_total` by `channel`
- Top failing templates panel stays entity-derived from the search snapshot
- Exports `notificationAnalyticsSpec` (`ServiceAnalyticsSpec`) for host apps to register on their `ThesaAnalyticsDataSource`
- Friendly gate error states: 400 (allowlist), 403 (unscoped), 5xx (backend down); tenant/partition filters are never sent client-side (server injects scoping from the JWT)

## KPI -> metric mapping
| KPI | Metric | Aggregation |
| --- | --- | --- |
| Sent | `notifications_sent_total` | sum |
| Delivered | `notifications_delivered_total` | sum |
| Failed | `notifications_failed_total` | sum |
| Queued | `notifications_queued_total` | sum |
| Avg send time (ms) | `notifications_send_duration_ms` | avg |

## Notes
- `antinvestor_ui_core: ^0.5.0` is not published yet (pub.dev has 0.4.1); CI for UI packages is lenient/non-blocking. Local development uses a gitignored `pubspec_overrides.yaml` path override against the `common` repo branch `feat/ui-core-thesa-analytics`.

## Testing
- Mocked-transport contract tests assert the exact POST bodies for scalar/timeseries/grouped queries and that no tenant/partition filters leak
- Widget tests cover KPI rendering, channel mix legend, empty data, and 400/403/503 friendly error states
- `flutter analyze --no-fatal-infos` clean, `dart format` clean (touched files), `flutter test` green (57 tests)