### PR TITLE
fix(ui): channel selector could never change selection — release 0.3.2

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.2
+
+- Fix: the channel selector on `NotificationSendScreen` could never change
+  selection — `channels.first` returned the previously selected channel
+  (set insertion order), so taps on other chips were no-ops. The newly
+  tapped channel is now selected.
+
 ## 0.3.0
 
 - `NotificationDashboardScreen` now sources KPIs (sent, delivered, failed,

--- a/ui/lib/src/screens/notification_send_screen.dart
+++ b/ui/lib/src/screens/notification_send_screen.dart
@@ -135,8 +135,16 @@ class _NotificationSendScreenState
                 child: ChannelSelector(
                   selectedChannels: {_selectedChannel},
                   onChanged: (channels) {
-                    setState(() => _selectedChannel =
-                        channels.isNotEmpty ? channels.first : _selectedChannel);
+                    // Single-select semantics over a multi-select widget:
+                    // the set still contains the previous channel, so pick
+                    // the newly tapped one — `channels.first` would always
+                    // return the old selection (insertion order) and the
+                    // channel could never change.
+                    final next = channels.firstWhere(
+                      (c) => c != _selectedChannel,
+                      orElse: () => _selectedChannel,
+                    );
+                    setState(() => _selectedChannel = next);
                   },
                 ),
               ),

--- a/ui/pubspec.yaml
+++ b/ui/pubspec.yaml
@@ -2,7 +2,7 @@ name: antinvestor_ui_notification
 description: >
   Notification management UI library for Antinvestor. Embeddable screens and widgets
   for sending, receiving, searching notifications, and managing templates.
-version: 0.3.1
+version: 0.3.2
 repository: https://github.com/antinvestor/service-notification
 homepage: https://github.com/antinvestor/service-notification/tree/main/ui
 issue_tracker: https://github.com/antinvestor/service-notification/issues


### PR DESCRIPTION
NotificationSendScreen mapped the multi-select ChannelSelector back to single-select with `channels.first`, which by set insertion order is always the previously selected channel — tapping any other chip was a no-op, so only SMS could ever be sent from the thesa console. Select the newly tapped channel instead. Bumps antinvestor_ui_notification to 0.3.2 (57/57 tests pass).