### PR TITLE
fix(ui): surface send-screen failures that looked like a dead button — 0.3.3

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.3
+
+- `NotificationSendScreen` now surfaces failures that previously looked
+  like a dead Send button: a snackbar appears when form validation fails
+  (the invalid field may be scrolled out of view) and when the send RPC
+  errors (mirroring the inline banner).
+
 ## 0.3.2
 
 - Fix: the channel selector on `NotificationSendScreen` could never change

--- a/ui/lib/src/screens/notification_send_screen.dart
+++ b/ui/lib/src/screens/notification_send_screen.dart
@@ -365,7 +365,17 @@ class _NotificationSendScreenState
   }
 
   Future<void> _send() async {
-    if (!_formKey.currentState!.validate()) return;
+    if (!_formKey.currentState!.validate()) {
+      // The invalid field may be scrolled out of view — without this the
+      // Send button appears to do nothing.
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Please fix the highlighted fields before sending'),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      return;
+    }
 
     setState(() {
       _sending = true;
@@ -424,6 +434,14 @@ class _NotificationSendScreenState
           _sending = false;
           _error = friendlyError(e);
         });
+        // Mirror the inline banner with a snackbar so the failure is
+        // visible even when the banner is scrolled out of view.
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(friendlyError(e)),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
       }
     }
   }

--- a/ui/pubspec.yaml
+++ b/ui/pubspec.yaml
@@ -2,7 +2,7 @@ name: antinvestor_ui_notification
 description: >
   Notification management UI library for Antinvestor. Embeddable screens and widgets
   for sending, receiving, searching notifications, and managing templates.
-version: 0.3.2
+version: 0.3.3
 repository: https://github.com/antinvestor/service-notification
 homepage: https://github.com/antinvestor/service-notification/tree/main/ui
 issue_tracker: https://github.com/antinvestor/service-notification/issues


### PR DESCRIPTION
Validation failures and send RPC errors on NotificationSendScreen were
invisible when the relevant field/banner was scrolled out of view, so
clicking Send appeared to do nothing. Both paths now also raise a
snackbar.
