### PR TITLE
fix(notification): GetOrCreateByCode created on the wrong branch

### DIFF
--- a/apps/default/service/repository/language.go
+++ b/apps/default/service/repository/language.go
@@ -49,7 +49,12 @@ func (repo *languageRepository) GetOrCreateByCode(ctx context.Context, languageC
 
 	lang, err := repo.GetByCode(ctx, languageCode)
 	if err != nil {
-		if data.ErrorIsNoRows(err) {
+		// Only "no rows" should trigger auto-creation — any other error is
+		// a real failure. The previous logic was inverted (it returned on
+		// no-rows and created on real errors), so the first notification in
+		// a partition that had no language row yet failed with "record not
+		// found" instead of provisioning the language.
+		if !data.ErrorIsNoRows(err) {
 			return nil, err
 		}
 
@@ -60,9 +65,8 @@ func (repo *languageRepository) GetOrCreateByCode(ctx context.Context, languageC
 		}
 		lang.GenID(ctx)
 
-		err = repo.Create(ctx, lang)
-		if err != nil {
-			return nil, err
+		if createErr := repo.Create(ctx, lang); createErr != nil {
+			return nil, createErr
 		}
 	}
 


### PR DESCRIPTION
The no-rows check was inverted: GetOrCreateByCode returned the error
when the language row was missing and only auto-created on other
(real) errors. So the first notification in any partition without a
pre-seeded language row failed with "record not found" — e.g. every
send in the Thesa Development tenant, whose only seeded language lived
under the root tenant.

Now a missing row provisions the language for the partition and any
other error propagates, matching the method name and the QueueIn
test's expectation.
