### PR TITLE
fix(ui): inbox filter chips below breadcrumb via list-page filters slot — 0.3.4

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.4
+
+- Inbox channel/language filter chips now render in AdminEntityListPage's
+  `filters` slot (requires antinvestor_ui_core ^0.5.1), so they sit below
+  the breadcrumb instead of floating above the page header.
+
 ## 0.3.3
 
 - `NotificationSendScreen` now surfaces failures that previously looked

--- a/ui/lib/src/screens/notification_inbox_screen.dart
+++ b/ui/lib/src/screens/notification_inbox_screen.dart
@@ -43,69 +43,65 @@ class _NotificationInboxScreenState
       orElse: () => const <notif.Language>[],
     );
 
-    return Column(
+    // Channel + language filter chips, passed to AdminEntityListPage's
+    // filters slot so they render below the breadcrumb instead of above it.
+    final filtersBar = Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        // Type filter chips
-        Padding(
-          padding: const EdgeInsets.fromLTRB(24, 16, 24, 0),
-          child: SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            child: Row(
-              children: [
-                _filterChip(theme, '', 'All'),
-                const SizedBox(width: 8),
-                _filterChip(theme, 'SMS', 'SMS'),
-                const SizedBox(width: 8),
-                _filterChip(theme, 'EMAIL', 'Email'),
-                const SizedBox(width: 8),
-                _filterChip(theme, 'PUSH', 'Push'),
-                const SizedBox(width: 8),
-                _filterChip(theme, 'WHATSAPP', 'WhatsApp'),
-              ],
-            ),
-          ),
-        ),
-        // Language filter chips (populated from languageSearchProvider)
-        Padding(
-          padding: const EdgeInsets.fromLTRB(24, 8, 24, 0),
-          child: SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            child: Row(
-              children: [
-                _langChip(theme, '', 'All', keySuffix: 'all'),
-                for (final l in langs) ...[
-                  const SizedBox(width: 8),
-                  _langChip(theme, l.code, l.name.isEmpty ? l.code : l.name),
-                ],
-              ],
-            ),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            children: [
+              _filterChip(theme, '', 'All'),
+              const SizedBox(width: 8),
+              _filterChip(theme, 'SMS', 'SMS'),
+              const SizedBox(width: 8),
+              _filterChip(theme, 'EMAIL', 'Email'),
+              const SizedBox(width: 8),
+              _filterChip(theme, 'PUSH', 'Push'),
+              const SizedBox(width: 8),
+              _filterChip(theme, 'WHATSAPP', 'WhatsApp'),
+            ],
           ),
         ),
         const SizedBox(height: 8),
-        // Main list
-        Expanded(
-          child: asyncNotifications.when(
-            loading: () => const Center(child: CircularProgressIndicator()),
-            error: (error, _) => Center(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(Icons.error_outline,
-                      size: 48, color: theme.colorScheme.error),
-                  const SizedBox(height: 16),
-                  Text('$error', style: theme.textTheme.bodyLarge),
-                  const SizedBox(height: 16),
-                  FilledButton.tonal(
-                    onPressed: _refresh,
-                    child: const Text('Retry'),
-                  ),
-                ],
-              ),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            children: [
+              _langChip(theme, '', 'All', keySuffix: 'all'),
+              for (final l in langs) ...[
+                const SizedBox(width: 8),
+                _langChip(theme, l.code, l.name.isEmpty ? l.code : l.name),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+
+    return asyncNotifications.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, _) => Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.error_outline,
+                size: 48, color: theme.colorScheme.error),
+            const SizedBox(height: 16),
+            Text('$error', style: theme.textTheme.bodyLarge),
+            const SizedBox(height: 16),
+            FilledButton.tonal(
+              onPressed: _refresh,
+              child: const Text('Retry'),
             ),
-            data: (notifications) => AdminEntityListPage<notif.Notification>(
-              title: 'Notifications',
-              breadcrumbs: const ['Home', 'Notifications'],
+          ],
+        ),
+      ),
+      data: (notifications) => AdminEntityListPage<notif.Notification>(
+        title: 'Notifications',
+        breadcrumbs: const ['Home', 'Notifications'],
+        filters: filtersBar,
               columns: const [
                 DataColumn(label: Text('Type')),
                 DataColumn(label: Text('Template')),
@@ -155,10 +151,7 @@ class _NotificationInboxScreenState
                 debugPrint(
                     '[AUDIT] Exported $count Notifications as $format');
               },
-            ),
-          ),
-        ),
-      ],
+      ),
     );
   }
 

--- a/ui/pubspec.yaml
+++ b/ui/pubspec.yaml
@@ -2,7 +2,7 @@ name: antinvestor_ui_notification
 description: >
   Notification management UI library for Antinvestor. Embeddable screens and widgets
   for sending, receiving, searching notifications, and managing templates.
-version: 0.3.3
+version: 0.3.4
 repository: https://github.com/antinvestor/service-notification
 homepage: https://github.com/antinvestor/service-notification/tree/main/ui
 issue_tracker: https://github.com/antinvestor/service-notification/issues
@@ -22,7 +22,7 @@ dependencies:
   # 0.5.0 ships the thesa-gated analytics pipeline (ServiceAnalyticsSpec,
   # ThesaAnalyticsDataSource). Not on pub.dev yet -- develop against the
   # local checkout via the gitignored pubspec_overrides.yaml.
-  antinvestor_ui_core: ^0.5.0
+  antinvestor_ui_core: ^0.5.1
   antinvestor_api_notification: ^1.53.0
   antinvestor_api_common: ^1.52.0
   connectrpc: ^1.0.0

--- a/ui/test/screens/notification_inbox_screen_test.dart
+++ b/ui/test/screens/notification_inbox_screen_test.dart
@@ -54,10 +54,22 @@ void main() {
     ));
     // AdminEntityListPage uses a DropdownButton in its pagination footer that
     // keeps the animation system busy; pump a fixed duration instead.
+    // The filter chips now live in the list page's filters slot (rendered
+    // below the breadcrumb), which only appears once the notification list
+    // resolves — pump until the chip exists rather than a single fixed wait.
+    // The filter chips now live in the list page's filters slot, which
+    // renders once the stream-backed notification + language providers
+    // resolve. Flush those async gaps with runAsync, then pump frames.
+    final langChip = find.byKey(const Key('inbox-lang-en'));
+    for (var i = 0; i < 30 && langChip.evaluate().isEmpty; i++) {
+      await tester.runAsync(() => Future<void>.delayed(
+          const Duration(milliseconds: 20)));
+      await tester.pump(const Duration(milliseconds: 20));
+    }
+    await tester.ensureVisible(langChip);
     await tester.pump();
-    await tester.pump(const Duration(milliseconds: 500));
 
-    await tester.tap(find.byKey(const Key('inbox-lang-en')));
+    await tester.tap(langChip);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
 


### PR DESCRIPTION
Channel and language filter chips were stacked above AdminEntityListPage,
so they rendered above the page's own breadcrumb. They now go in the new
filters slot (ui_core ^0.5.1), placing them under the breadcrumb. Bumps
ui_core constraint to ^0.5.1.
